### PR TITLE
Add is_banned boolean to Account and Tag models

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -28,6 +28,7 @@
 #  hide_collections              :boolean
 #  inbox_url                     :string           default(""), not null
 #  indexable                     :boolean          default(FALSE), not null
+#  is_banned                     :boolean          default(FALSE)
 #  last_webfingered_at           :datetime
 #  locked                        :boolean          default(FALSE), not null
 #  memorial                      :boolean          default(FALSE), not null

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  display_name        :string
+#  is_banned           :boolean          default(FALSE)
 #  last_status_at      :datetime
 #  listable            :boolean
 #  max_score           :float

--- a/db/migrate/20240423090721_create_server_settings.rb
+++ b/db/migrate/20240423090721_create_server_settings.rb
@@ -1,6 +1,6 @@
 class CreateServerSettings < ActiveRecord::Migration[7.0]
   def change
-    create_table :server_settings do |t|
+    create_table :server_settings, if_not_exists: true do |t|
       t.string :name
       t.string :optional_value
       t.boolean :value

--- a/db/migrate/20241210031002_create_patchwork_notification_tokens.rb
+++ b/db/migrate/20241210031002_create_patchwork_notification_tokens.rb
@@ -1,6 +1,6 @@
 class CreatePatchworkNotificationTokens < ActiveRecord::Migration[7.1]
   def change
-    create_table :patchwork_notification_tokens do |t|
+    create_table :patchwork_notification_tokens, if_not_exists: true do |t|
       t.references :account, null: false, foreign_key: {to_table: :accounts}
       t.string :notification_token
       t.string :platform_type

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_28_083539) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_04_100021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -199,6 +199,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_28_083539) do
     t.boolean "indexable", default: false, null: false
     t.string "attribution_domains", default: [], array: true
     t.string "devices_url"
+    t.boolean "is_banned", default: false
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"
@@ -1382,6 +1383,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_28_083539) do
     t.datetime "edited_at", precision: nil
     t.boolean "trendable"
     t.bigint "ordered_media_attachment_ids", array: true
+    t.boolean "is_banned", default: false
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
     t.index ["account_id"], name: "index_statuses_on_account_id"
     t.index ["deleted_at"], name: "index_statuses_on_deleted_at", where: "(deleted_at IS NOT NULL)"
@@ -1430,6 +1432,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_28_083539) do
     t.float "max_score"
     t.datetime "max_score_at", precision: nil
     t.string "display_name"
+    t.boolean "is_banned", default: false
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
   end
 


### PR DESCRIPTION
Introduces an is_banned boolean field with default false to both the Account and Tag models. Also updates related schema and model documentation. Additionally, migration files now use if_not_exists for table creation to prevent errors on repeated runs.