### PR TITLE
Add column existence checks to migrations

### DIFF
--- a/db/migrate/20241112065538_modify_patchwork_communities_admins.rb
+++ b/db/migrate/20241112065538_modify_patchwork_communities_admins.rb
@@ -2,9 +2,17 @@ class ModifyPatchworkCommunitiesAdmins < ActiveRecord::Migration[7.1]
   def change
     remove_reference :patchwork_communities_admins, :account, foreign_key: true
 
-    add_column :patchwork_communities_admins, :display_name, :string
-    add_column :patchwork_communities_admins, :email, :string
-    add_column :patchwork_communities_admins, :username, :string
-    add_column :patchwork_communities_admins, :password, :string
+    unless column_exists?(:patchwork_communities_admins, :display_name)
+      add_column :patchwork_communities_admins, :display_name, :string
+    end
+    unless column_exists?(:patchwork_communities_admins, :email)
+      add_column :patchwork_communities_admins, :email, :string
+    end
+    unless column_exists?(:patchwork_communities_admins, :username)
+      add_column :patchwork_communities_admins, :username, :string
+    end
+    unless column_exists?(:patchwork_communities_admins, :password)
+      add_column :patchwork_communities_admins, :password, :string
+    end
   end
 end

--- a/db/migrate/20241201170720_add_role_to_community_admins.rb
+++ b/db/migrate/20241201170720_add_role_to_community_admins.rb
@@ -1,5 +1,7 @@
 class AddRoleToCommunityAdmins < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities_admins, :role, :string
+    unless column_exists?(:patchwork_communities_admins, :role)
+      add_column :patchwork_communities_admins, :role, :string
+    end
   end
 end

--- a/db/migrate/20241205101306_add_channel_type_to_communities.rb
+++ b/db/migrate/20241205101306_add_channel_type_to_communities.rb
@@ -1,5 +1,7 @@
 class AddChannelTypeToCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities, :channel_type, :string, default: 'channel', null: false
+    unless column_exists?(:patchwork_communities, :channel_type)
+      add_column :patchwork_communities, :channel_type, :string, default: 'channel', null: false
+    end
   end
 end

--- a/db/migrate/20241206064839_add_is_boost_bot_to_community_admin.rb
+++ b/db/migrate/20241206064839_add_is_boost_bot_to_community_admin.rb
@@ -1,5 +1,7 @@
 class AddIsBoostBotToCommunityAdmin < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities_admins, :is_boost_bot, :boolean, default: false, null: false
+    unless column_exists?(:patchwork_communities_admins, :is_boost_bot)
+      add_column :patchwork_communities_admins, :is_boost_bot, :boolean, default: false, null: false
+    end
   end
 end

--- a/db/migrate/20241216061104_add_filter_type_to_patchwork_communities_filter_keywords.rb
+++ b/db/migrate/20241216061104_add_filter_type_to_patchwork_communities_filter_keywords.rb
@@ -1,5 +1,7 @@
 class AddFilterTypeToPatchworkCommunitiesFilterKeywords < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities_filter_keywords, :filter_type, :string, default: 'filter_out', null: false
+    unless column_exists?(:patchwork_communities_filter_keywords, :filter_type)
+      add_column :patchwork_communities_filter_keywords, :filter_type, :string, default: 'filter_out', null: false
+    end
   end
 end

--- a/db/migrate/20241218044104_add_rule_to_patchwork_community_rules.rb
+++ b/db/migrate/20241218044104_add_rule_to_patchwork_community_rules.rb
@@ -1,5 +1,7 @@
 class AddRuleToPatchworkCommunityRules < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_community_rules, :rule, :string
+    unless column_exists?(:patchwork_community_rules, :rule)
+      add_column :patchwork_community_rules, :rule, :string
+    end
   end
 end

--- a/db/migrate/20250110073700_add_ddl_value_to_communities.rb
+++ b/db/migrate/20250110073700_add_ddl_value_to_communities.rb
@@ -1,5 +1,7 @@
 class AddDdlValueToCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities, :ddl_value, :string, default: nil, null: true
+    unless column_exists?(:patchwork_communities, :ddl_value)
+      add_column :patchwork_communities, :ddl_value, :string, default: nil, null: true
+    end
   end
 end

--- a/db/migrate/20250111073700_remove_ddl_value_to_communities.rb
+++ b/db/migrate/20250111073700_remove_ddl_value_to_communities.rb
@@ -1,6 +1,8 @@
 class RemoveDdlValueToCommunities < ActiveRecord::Migration[7.1]
   def change
     remove_column :patchwork_communities, :ddl_value
-    add_column :patchwork_communities, :did_value, :string, default: nil, null: true
+    unless column_exists?(:patchwork_communities, :did_value)
+      add_column :patchwork_communities, :did_value, :string, default: nil, null: true
+    end
   end
 end

--- a/db/migrate/20250204110455_add_is_social_to_community_links.rb
+++ b/db/migrate/20250204110455_add_is_social_to_community_links.rb
@@ -1,5 +1,7 @@
 class AddIsSocialToCommunityLinks < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_community_links, :is_social, :boolean, default: false
+    unless column_exists?(:patchwork_community_links, :is_social)
+      add_column :patchwork_community_links, :is_social, :boolean, default: false
+    end
   end
 end

--- a/db/migrate/20250303081432_add_is_custom_domain_to_communities.rb
+++ b/db/migrate/20250303081432_add_is_custom_domain_to_communities.rb
@@ -1,5 +1,7 @@
 class AddIsCustomDomainToCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities, :is_custom_domain, :boolean, default: false, null: false
+    unless column_exists?(:patchwork_communities, :is_custom_domain)
+      add_column :patchwork_communities, :is_custom_domain, :boolean, default: false, null: false
+    end
   end
 end

--- a/db/migrate/20250310092025_add_registration_mode_to_communities.rb
+++ b/db/migrate/20250310092025_add_registration_mode_to_communities.rb
@@ -1,5 +1,7 @@
 class AddRegistrationModeToCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities, :registration_mode, :string, default: 'none'
+    unless column_exists?(:patchwork_communities, :registration_mode)
+      add_column :patchwork_communities, :registration_mode, :string, default: 'none'
+    end
   end
 end

--- a/db/migrate/20250324090740_add_mute_notification_tokens.rb
+++ b/db/migrate/20250324090740_add_mute_notification_tokens.rb
@@ -2,9 +2,11 @@ class AddMuteNotificationTokens < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def self.up
+    unless column_exists?(:patchwork_notification_tokens, :mute)
       change_table :patchwork_notification_tokens do |t|
         t.boolean :mute, null: false, default: false
       end
+    end
   end
 
   def self.down

--- a/db/migrate/20250326102145_add_private_ip_to_ip_addresses.rb
+++ b/db/migrate/20250326102145_add_private_ip_to_ip_addresses.rb
@@ -1,5 +1,7 @@
 class AddPrivateIpToIpAddresses < ActiveRecord::Migration[7.1]
   def change
-    add_column :ip_addresses, :private_ip, :string
+    unless column_exists?(:ip_addresses, :private_ip)
+      add_column :ip_addresses, :private_ip, :string
+    end
   end
 end

--- a/db/migrate/20250425062202_add_deleted_at_to_channels_and_communities.rb
+++ b/db/migrate/20250425062202_add_deleted_at_to_channels_and_communities.rb
@@ -1,5 +1,7 @@
 class AddDeletedAtToChannelsAndCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities, :deleted_at, :datetime
+    unless column_exists?(:patchwork_communities, :deleted_at)
+      add_column :patchwork_communities, :deleted_at, :datetime
+    end
   end
 end

--- a/db/migrate/20250513002202_add_is_primary_to_patchwork_joined_communities.rb
+++ b/db/migrate/20250513002202_add_is_primary_to_patchwork_joined_communities.rb
@@ -1,5 +1,7 @@
 class AddIsPrimaryToPatchworkJoinedCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_joined_communities, :is_primary, :boolean, default: false, null: false
+    unless column_exists?(:patchwork_joined_communities, :is_primary)
+      add_column :patchwork_joined_communities, :is_primary, :boolean, default: false, null: false
+    end
   end
 end

--- a/db/migrate/20250530082427_add_app_name_to_patchwork_app_versions.rb
+++ b/db/migrate/20250530082427_add_app_name_to_patchwork_app_versions.rb
@@ -1,5 +1,7 @@
 class AddAppNameToPatchworkAppVersions < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_app_versions, :app_name, :integer, default: 0, null: false
+    unless column_exists?(:patchwork_app_versions, :app_name)
+      add_column :patchwork_app_versions, :app_name, :integer, default: 0, null: false
+    end
   end
 end

--- a/db/migrate/20250619053704_add_post_visibility_to_communities.rb
+++ b/db/migrate/20250619053704_add_post_visibility_to_communities.rb
@@ -1,5 +1,7 @@
 class AddPostVisibilityToCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities, :post_visibility, :integer, default: 2, null: false
+    unless column_exists?(:patchwork_communities, :post_visibility)
+      add_column :patchwork_communities, :post_visibility, :integer, default: 2, null: false
+    end
   end
 end

--- a/db/migrate/20250711090953_add_about_to_communities.rb
+++ b/db/migrate/20250711090953_add_about_to_communities.rb
@@ -1,5 +1,7 @@
 class AddAboutToCommunities < ActiveRecord::Migration[7.1]
   def change
-    add_column :patchwork_communities, :about, :string
+    unless column_exists?(:patchwork_communities, :about)
+      add_column :patchwork_communities, :about, :string
+    end
   end
 end


### PR DESCRIPTION
Updated multiple migration files to wrap add_column statements with column_exists? checks. This prevents errors when running migrations multiple times or in environments where columns may already exist.